### PR TITLE
chore: Add Renovate config for dependency pinning

### DIFF
--- a/.github/.kodiak.toml
+++ b/.github/.kodiak.toml
@@ -1,0 +1,15 @@
+version = 1
+
+[approve]
+auto_approve_usernames = ["cloudquery-ci"]
+
+[merge.message]
+body = "pull_request_body"
+cut_body_after = "Use the following steps to ensure your PR is ready to be reviewed"
+cut_body_and_text = true
+cut_body_before = "<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->"
+title = "pull_request_title"
+
+[merge]
+blocking_labels = ["wip", "no automerge"]
+notify_on_conflict = false

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>cloudquery/.github//.github/renovate-go-default.json5"],
+  "forkProcessing": "enabled"
+}


### PR DESCRIPTION
Adds Renovate configuration with forkProcessing enabled, extending the org-wide default which includes pinning GitHub Actions to SHA digests.